### PR TITLE
Filter interface 구조 리팩터링

### DIFF
--- a/data/src/main/java/com/exhibitiondot/data/mapper/FilterMapper.kt
+++ b/data/src/main/java/com/exhibitiondot/data/mapper/FilterMapper.kt
@@ -4,47 +4,11 @@ import com.exhibitiondot.domain.model.Category
 import com.exhibitiondot.domain.model.EventType
 import com.exhibitiondot.domain.model.Region
 
-fun String.toRegion(): Region {
-    return when(this) {
-        Region.Seoul.name -> Region.Seoul
-        Region.Gyeonggi.name -> Region.Gyeonggi
-        Region.Chungcheoung.name -> Region.Chungcheoung
-        Region.Jeolla.name -> Region.Jeolla
-        Region.Gyeongsang.name -> Region.Gyeongsang
-        Region.Gangwon.name -> Region.Gangwon
-        Region.Jeju.name -> Region.Jeju
-        else -> throw IllegalArgumentException()
-    }
-}
+fun String.toRegion(): Region =
+    Region.fromKey(this) ?: throw IllegalArgumentException("알 수 없는 Region key: $this")
 
-fun String.toCategory(): Category {
-    return when (this) {
-        Category.IT.key -> Category.IT
-        Category.Interior.key -> Category.Interior
-        Category.Health.key -> Category.Health
-        Category.Fashion.key -> Category.Fashion
-        Category.Science.key -> Category.Science
-        Category.Design.key -> Category.Design
-        Category.Education.key -> Category.Education
-        Category.Finance.key -> Category.Finance
-        Category.Performance.key -> Category.Performance
-        Category.Entertainment.key -> Category.Entertainment
-        Category.Environment.key -> Category.Environment
-        Category.Food.key -> Category.Food
-        Category.ETC.key -> Category.ETC
-        else -> throw IllegalArgumentException()
-    }
-}
+fun String.toCategory(): Category =
+    Category.fromKey(this) ?: throw IllegalArgumentException("알 수 없는 Category key: $this")
 
-fun String.toEventType(): EventType {
-    return when (this) {
-        EventType.Exhibition.key -> EventType.Exhibition
-        EventType.Festival.key -> EventType.Festival
-        EventType.Fair.key -> EventType.Fair
-        EventType.Convention.key -> EventType.Convention
-        EventType.ChildrenExperience.key -> EventType.ChildrenExperience
-        EventType.Museum.key -> EventType.Museum
-        EventType.Musical.key -> EventType.Musical
-        else -> throw  IllegalArgumentException()
-    }
-}
+fun String.toEventType(): EventType =
+    EventType.fromKey(this) ?: throw IllegalArgumentException("알 수 없는 EventType key: $this")

--- a/domain/src/main/java/com/exhibitiondot/domain/model/EventParams.kt
+++ b/domain/src/main/java/com/exhibitiondot/domain/model/EventParams.kt
@@ -14,7 +14,7 @@ data class EventParams(
     }
 
     fun regionText(default: String): String {
-        return region?.name ?: default
+        return region?.displayName ?: default
     }
 
     fun categoryText(default: String): String {

--- a/domain/src/main/java/com/exhibitiondot/domain/model/Filter.kt
+++ b/domain/src/main/java/com/exhibitiondot/domain/model/Filter.kt
@@ -4,68 +4,60 @@ interface Filter {
     val key: String
 }
 
-interface SingleFilter : Filter {
-    val name: String
-}
+interface SingleFilter : Filter
 
 interface MultiFilter : Filter
 
-sealed class Region(
-    override val key: String,
-    override val name: String,
-) : SingleFilter {
-    data object Seoul : Region(key = "seoul", name = "서울")
-    data object Gyeonggi : Region(key = "gyeonggi", name = "경기도")
-    data object Chungcheoung : Region(key = "chungcheong", name = "충청도")
-    data object Jeolla : Region(key = "jeolla", name = "전라도")
-    data object Gyeongsang : Region(key = "gyeongsang", name = "경상도")
-    data object Gangwon : Region(key = "gangwon", name = "강원도")
-    data object Jeju : Region(key = "jeju", name = "제주도")
+enum class Region(override val key: String) : SingleFilter {
+    SEOUL("seoul"),
+    GYEONGGI("gyeonggi"),
+    CHUNGCHEONG("chungcheong"),
+    JEOLLA("jeolla"),
+    GYEONGSANG("gyeongsang"),
+    GANGWON("gangwon"),
+    JEJU("jeju");
 
     companion object {
-        fun values(): List<Region> =
-            listOf(Seoul, Gyeonggi, Chungcheoung, Jeolla, Gyeongsang, Gangwon, Jeju)
+        private val map = entries.associateBy(Region::key)
+
+        fun fromKey(key: String): Region? = map[key]
     }
 }
 
-sealed class Category(override val key: String) : MultiFilter {
-    data object IT : Category("전기/전자/IT")
-    data object Interior : Category("건설/건축/인테리어")
-    data object Health : Category("의료/건강/스포츠")
-    data object Fashion : Category("섬유/의류/패션")
-    data object Science : Category("기계/과학/기술")
-    data object Design : Category("예술/디자인")
-    data object Education : Category("교육/출판")
-    data object Finance : Category("금융/재테크")
-    data object Performance : Category("공연/이벤트")
-    data object Entertainment : Category("관광/오락")
-    data object Environment : Category("환경/에너지")
-    data object Food : Category("농수산/식음료")
-    data object ETC : Category("기타")
+enum class Category(override val key: String) : MultiFilter {
+    IT("전기/전자/IT"),
+    INTERIOR("건설/건축/인테리어"),
+    HEALTH("의료/건강/스포츠"),
+    FASHION("섬유/의류/패션"),
+    SCIENCE("기계/과학/기술"),
+    DESIGN("예술/디자인"),
+    EDUCATION("교육/출판"),
+    FINANCE("금융/재테크"),
+    PERFORMANCE("공연/이벤트"),
+    ENTERTAINMENT("관광/오락"),
+    ENVIRONMENT("환경/에너지"),
+    FOOD("농수산/식음료"),
+    ETC("기타");
 
     companion object {
-        fun values(): List<Category> =
-            listOf(
-                IT, Interior, Health, Fashion, Science, Design, Education,
-                Finance, Performance, Entertainment, Environment, Food, ETC
-            )
+        private val map = entries.associateBy(Category::key)
+
+        fun fromKey(key: String): Category? = map[key]
     }
 }
 
-sealed class EventType(override val key: String) : MultiFilter {
-    data object Exhibition : EventType("전시회")
-    data object Festival : EventType("행사/축제")
-    data object Fair : EventType("박람회")
-    data object Convention : EventType("컨벤션")
-    data object ChildrenExperience : EventType("아동체험전")
-    data object Museum : EventType("박물관")
-    data object Musical : EventType("뮤지컬/콘서트")
+enum class EventType(override val key: String) : MultiFilter {
+    EXHIBITION("전시회"),
+    FESTIVAL("행사/축제"),
+    FAIR("박람회"),
+    CONVENTION("컨벤션"),
+    CHILDREN_EXPERIENCE("아동체험전"),
+    MUSEUM("박물관"),
+    MUSICAL("뮤지컬/콘서트");
 
     companion object {
-        fun values(): List<EventType> =
-            listOf(
-                Exhibition, Festival, Fair, Convention,
-                ChildrenExperience, Museum, Musical
-            )
+        private val map = entries.associateBy(EventType::key)
+
+        fun fromKey(key: String): EventType? = map[key]
     }
 }

--- a/domain/src/main/java/com/exhibitiondot/domain/model/Filter.kt
+++ b/domain/src/main/java/com/exhibitiondot/domain/model/Filter.kt
@@ -1,11 +1,19 @@
 package com.exhibitiondot.domain.model
 
-sealed interface Filter {
-    sealed interface SingleFilter : Filter
-    sealed interface MultiFilter : Filter
+interface Filter {
+    val key: String
 }
 
-sealed class Region(val key: String, val name: String) : Filter.SingleFilter {
+interface SingleFilter : Filter {
+    val name: String
+}
+
+interface MultiFilter : Filter
+
+sealed class Region(
+    override val key: String,
+    override val name: String,
+) : SingleFilter {
     data object Seoul : Region(key = "seoul", name = "서울")
     data object Gyeonggi : Region(key = "gyeonggi", name = "경기도")
     data object Chungcheoung : Region(key = "chungcheong", name = "충청도")
@@ -20,7 +28,7 @@ sealed class Region(val key: String, val name: String) : Filter.SingleFilter {
     }
 }
 
-sealed class Category(val key: String) : Filter.MultiFilter {
+sealed class Category(override val key: String) : MultiFilter {
     data object IT : Category("전기/전자/IT")
     data object Interior : Category("건설/건축/인테리어")
     data object Health : Category("의료/건강/스포츠")
@@ -44,7 +52,7 @@ sealed class Category(val key: String) : Filter.MultiFilter {
     }
 }
 
-sealed class EventType(val key: String) : Filter.MultiFilter {
+sealed class EventType(override val key: String) : MultiFilter {
     data object Exhibition : EventType("전시회")
     data object Festival : EventType("행사/축제")
     data object Fair : EventType("박람회")

--- a/domain/src/main/java/com/exhibitiondot/domain/model/Filter.kt
+++ b/domain/src/main/java/com/exhibitiondot/domain/model/Filter.kt
@@ -4,21 +4,26 @@ interface Filter {
     val key: String
 }
 
-interface SingleFilter : Filter
+interface SingleFilter : Filter {
+    val displayName: String
+}
 
 interface MultiFilter : Filter
 
-enum class Region(override val key: String) : SingleFilter {
-    SEOUL("seoul"),
-    GYEONGGI("gyeonggi"),
-    CHUNGCHEONG("chungcheong"),
-    JEOLLA("jeolla"),
-    GYEONGSANG("gyeongsang"),
-    GANGWON("gangwon"),
-    JEJU("jeju");
+enum class Region(
+    override val key: String,
+    override val displayName: String,
+) : SingleFilter {
+    SEOUL("seoul", "서울"),
+    GYEONGGI("gyeonggi", "경기도"),
+    CHUNGCHEONG("chungcheong", "충청도"),
+    JEOLLA("jeolla", "전라도"),
+    GYEONGSANG("gyeongsang", "경상도"),
+    GANGWON("gangwon", "강원도"),
+    JEJU("jeju", "제주도");
 
     companion object {
-        private val map = entries.associateBy(Region::key)
+        private val map = entries.associateBy(Region::displayName)
 
         fun fromKey(key: String): Region? = map[key]
     }

--- a/domain/src/main/java/com/exhibitiondot/domain/model/User.kt
+++ b/domain/src/main/java/com/exhibitiondot/domain/model/User.kt
@@ -15,7 +15,7 @@ data class User(
             name = "",
             phone = "",
             nickname = "",
-            region = Region.Seoul,
+            region = Region.SEOUL,
             categoryList = listOf(),
             eventTypeList = listOf()
         )

--- a/presentation/src/main/java/com/exhibitiondot/presentation/mapper/EventMapper.kt
+++ b/presentation/src/main/java/com/exhibitiondot/presentation/mapper/EventMapper.kt
@@ -20,7 +20,7 @@ fun EventDetail.toUiModel() =
         id = id,
         name = name,
         imgUrl = imgUrl,
-        region = region.name,
+        region = region.displayName,
         categoryTags = categoryList.joinToString(" ", transform = Category::toTag),
         eventTypeTags = eventTypeList.joinToString(" ", transform = EventType::toTag),
         date = format(DateFormatStrategy.FullDate(date)),

--- a/presentation/src/main/java/com/exhibitiondot/presentation/mapper/UserMapper.kt
+++ b/presentation/src/main/java/com/exhibitiondot/presentation/mapper/UserMapper.kt
@@ -11,7 +11,7 @@ fun User.toUiModel() =
         name = name,
         phone = phone,
         nickname = nickname,
-        region = region.name,
+        region = region.displayName,
         categoryTags = categoryList.joinToString(" ", transform = Category::toTag),
         eventTypeTags = eventTypeList.joinToString(" ", transform = EventType::toTag),
     )

--- a/presentation/src/main/java/com/exhibitiondot/presentation/ui/component/DoTBottomSheet.kt
+++ b/presentation/src/main/java/com/exhibitiondot/presentation/ui/component/DoTBottomSheet.kt
@@ -25,7 +25,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.exhibitiondot.domain.model.Filter
+import com.exhibitiondot.domain.model.MultiFilter
+import com.exhibitiondot.domain.model.SingleFilter
 import com.exhibitiondot.presentation.R
 import com.exhibitiondot.presentation.ui.state.IMultiFilerState
 import com.exhibitiondot.presentation.ui.state.ISingleFilterState
@@ -125,7 +126,7 @@ private fun HomeFilterSheet(
 }
 
 @Composable
-fun <T : Filter.SingleFilter> HomeSingleFilterSheet(
+fun <T : SingleFilter> HomeSingleFilterSheet(
     title: String,
     scope: CoroutineScope,
     filterState: ISingleFilterState<T>,
@@ -146,7 +147,7 @@ fun <T : Filter.SingleFilter> HomeSingleFilterSheet(
 }
 
 @Composable
-fun <T : Filter.MultiFilter> HomeMultiFilterSheet(
+fun <T : MultiFilter> HomeMultiFilterSheet(
     title: String,
     scope: CoroutineScope,
     filterState: IMultiFilerState<T>,

--- a/presentation/src/main/java/com/exhibitiondot/presentation/ui/component/DoTSelect.kt
+++ b/presentation/src/main/java/com/exhibitiondot/presentation/ui/component/DoTSelect.kt
@@ -5,15 +5,12 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.FlowRowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.exhibitiondot.domain.model.Category
-import com.exhibitiondot.domain.model.EventType
-import com.exhibitiondot.domain.model.Filter
-import com.exhibitiondot.domain.model.Region
+import com.exhibitiondot.domain.model.MultiFilter
+import com.exhibitiondot.domain.model.SingleFilter
 import com.exhibitiondot.presentation.R
 import com.exhibitiondot.presentation.ui.state.IMultiFilerState
 import com.exhibitiondot.presentation.ui.state.ISingleFilterState
@@ -36,7 +33,7 @@ private fun FilterSelectScreen(
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun <T : Filter.SingleFilter> SingleFilterSelectScreen(
+fun <T : SingleFilter> SingleFilterSelectScreen(
     modifier: Modifier = Modifier,
     filterState: ISingleFilterState<T>,
     needEntire: Boolean = false,
@@ -53,10 +50,7 @@ fun <T : Filter.SingleFilter> SingleFilterSelectScreen(
         }
         filterState.filterList.forEach { filter ->
             DoTFilterChip(
-                name = when (filter) {
-                    is Region -> filter.name
-                    else -> ""
-                },
+                name = filter.displayName,
                 selected = filter == filterState.selectedFilter,
                 onSelect = { filterState.selectFilter(filter) }
             )
@@ -66,7 +60,7 @@ fun <T : Filter.SingleFilter> SingleFilterSelectScreen(
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun <T : Filter.MultiFilter> MultiFilterSelectScreen(
+fun <T : MultiFilter> MultiFilterSelectScreen(
     modifier: Modifier = Modifier,
     filterState: IMultiFilerState<T>,
     needEntire: Boolean = false,
@@ -83,11 +77,7 @@ fun <T : Filter.MultiFilter> MultiFilterSelectScreen(
         }
         filterState.filterList.forEach { filter ->
             DoTFilterChip(
-                name = when (filter) {
-                    is Category -> filter.key
-                    is EventType -> filter.key
-                    else -> ""
-                },
+                name = filter.key,
                 selected = filter in filterState.selectedFilterList,
                 onSelect = { filterState.selectFilter(filter) }
             )

--- a/presentation/src/main/java/com/exhibitiondot/presentation/ui/screen/main/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/exhibitiondot/presentation/ui/screen/main/home/HomeViewModel.kt
@@ -55,9 +55,9 @@ class HomeViewModel @Inject constructor(
     var uiState by mutableStateOf<HomeUiState>(HomeUiState.Idle)
         private set
 
-    val regionState = SingleFilterState(filterList = Region.values())
-    val categoryState = MultiFilterForQueryState(filterList = Category.values())
-    val eventTypeState = MultiFilterForQueryState(filterList = EventType.values())
+    val regionState = SingleFilterState(Region.entries)
+    val categoryState = MultiFilterForQueryState(Category.entries)
+    val eventTypeState = MultiFilterForQueryState(EventType.entries)
 
     init {
         viewModelScope.launch {

--- a/presentation/src/main/java/com/exhibitiondot/presentation/ui/screen/main/postEvent/PostEventViewModel.kt
+++ b/presentation/src/main/java/com/exhibitiondot/presentation/ui/screen/main/postEvent/PostEventViewModel.kt
@@ -56,9 +56,9 @@ class PostEventViewModel @Inject constructor(
     val nameState = EditTextState(maxLength = 20)
     var selectedDate by mutableStateOf(format(DateFormatStrategy.Today))
         private set
-    val regionState = SingleFilterState(filterList = Region.values())
-    val categoryState = MultiFilterState(filterList = Category.values())
-    val eventTypeState = MultiFilterState(filterList = EventType.values())
+    val regionState = SingleFilterState(filterList = Region.entries)
+    val categoryState = MultiFilterState(filterList = Category.entries)
+    val eventTypeState = MultiFilterState(filterList = EventType.entries)
 
     init {
         eventId?.let {

--- a/presentation/src/main/java/com/exhibitiondot/presentation/ui/screen/main/postEvent/PostEventViewModel.kt
+++ b/presentation/src/main/java/com/exhibitiondot/presentation/ui/screen/main/postEvent/PostEventViewModel.kt
@@ -56,9 +56,9 @@ class PostEventViewModel @Inject constructor(
     val nameState = EditTextState(maxLength = 20)
     var selectedDate by mutableStateOf(format(DateFormatStrategy.Today))
         private set
-    val regionState = SingleFilterState(filterList = Region.entries)
-    val categoryState = MultiFilterState(filterList = Category.entries)
-    val eventTypeState = MultiFilterState(filterList = EventType.entries)
+    val regionState = SingleFilterState(Region.entries)
+    val categoryState = MultiFilterState(Category.entries)
+    val eventTypeState = MultiFilterState(EventType.entries)
 
     init {
         eventId?.let {

--- a/presentation/src/main/java/com/exhibitiondot/presentation/ui/screen/main/updateUserInfo/UpdateUserInfoViewModel.kt
+++ b/presentation/src/main/java/com/exhibitiondot/presentation/ui/screen/main/updateUserInfo/UpdateUserInfoViewModel.kt
@@ -31,9 +31,9 @@ class UpdateUserInfoViewModel @Inject constructor(
         private set
 
     val nicknameState = EditTextState(maxLength = 10)
-    val regionState = SingleFilterState(filterList = Region.values())
-    val categoryState = MultiFilterState(filterList = Category.values())
-    val eventTypeState = MultiFilterState(filterList = EventType.values())
+    val regionState = SingleFilterState(filterList = Region.entries)
+    val categoryState = MultiFilterState(filterList = Category.entries)
+    val eventTypeState = MultiFilterState(filterList = EventType.entries)
 
     init {
         viewModelScope.launch {

--- a/presentation/src/main/java/com/exhibitiondot/presentation/ui/screen/main/updateUserInfo/UpdateUserInfoViewModel.kt
+++ b/presentation/src/main/java/com/exhibitiondot/presentation/ui/screen/main/updateUserInfo/UpdateUserInfoViewModel.kt
@@ -31,9 +31,9 @@ class UpdateUserInfoViewModel @Inject constructor(
         private set
 
     val nicknameState = EditTextState(maxLength = 10)
-    val regionState = SingleFilterState(filterList = Region.entries)
-    val categoryState = MultiFilterState(filterList = Category.entries)
-    val eventTypeState = MultiFilterState(filterList = EventType.entries)
+    val regionState = SingleFilterState(Region.entries)
+    val categoryState = MultiFilterState(Category.entries)
+    val eventTypeState = MultiFilterState(EventType.entries)
 
     init {
         viewModelScope.launch {

--- a/presentation/src/main/java/com/exhibitiondot/presentation/ui/screen/sign/signUp/SignUpViewModel.kt
+++ b/presentation/src/main/java/com/exhibitiondot/presentation/ui/screen/sign/signUp/SignUpViewModel.kt
@@ -45,11 +45,11 @@ class SignUpViewModel @Inject constructor(
     val phoneState = PhoneEditTextState()
 
     val regionState = SingleFilterState(
-        initFilter = Region.Seoul,
-        filterList = Region.values()
+        initFilter = Region.SEOUL,
+        filterList = Region.entries
     )
-    val categoryState = MultiFilterState(filterList = Category.values())
-    val eventTypeState = MultiFilterState(filterList = EventType.values())
+    val categoryState = MultiFilterState(filterList = Category.entries)
+    val eventTypeState = MultiFilterState(filterList = EventType.entries)
 
     fun onPrevStep(onBack: () -> Unit) {
         val prevIdx = totalSteps.indexOf(currentStep) - 1

--- a/presentation/src/main/java/com/exhibitiondot/presentation/ui/screen/sign/signUp/SignUpViewModel.kt
+++ b/presentation/src/main/java/com/exhibitiondot/presentation/ui/screen/sign/signUp/SignUpViewModel.kt
@@ -44,12 +44,9 @@ class SignUpViewModel @Inject constructor(
     val nicknameState = EditTextState(maxLength = 10)
     val phoneState = PhoneEditTextState()
 
-    val regionState = SingleFilterState(
-        initFilter = Region.SEOUL,
-        filterList = Region.entries
-    )
-    val categoryState = MultiFilterState(filterList = Category.entries)
-    val eventTypeState = MultiFilterState(filterList = EventType.entries)
+    val regionState = SingleFilterState(Region.entries)
+    val categoryState = MultiFilterState(Category.entries)
+    val eventTypeState = MultiFilterState(EventType.entries)
 
     fun onPrevStep(onBack: () -> Unit) {
         val prevIdx = totalSteps.indexOf(currentStep) - 1
@@ -78,6 +75,7 @@ class SignUpViewModel @Inject constructor(
             SignUpStep.InfoStep -> {
                 nameState.isValidate() && nicknameState.isValidate() && phoneState.isValidate()
             }
+            SignUpStep.RegionStep -> regionState.selectedFilter != null
             else -> true
         }
     }

--- a/presentation/src/main/java/com/exhibitiondot/presentation/ui/state/FilterState.kt
+++ b/presentation/src/main/java/com/exhibitiondot/presentation/ui/state/FilterState.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.exhibitiondot.domain.model.Filter
+import com.exhibitiondot.domain.model.MultiFilter
+import com.exhibitiondot.domain.model.SingleFilter
 
 interface IFilterState<T : Filter> {
     val filterList: List<T>
@@ -11,21 +13,20 @@ interface IFilterState<T : Filter> {
     fun resetAll()
 }
 
-interface ISingleFilterState<T : Filter.SingleFilter> : IFilterState<T> {
+interface ISingleFilterState<T : SingleFilter> : IFilterState<T> {
     var selectedFilter: T?
     fun setFilter(filter: T?)
 }
 
-interface IMultiFilerState<T : Filter.MultiFilter> : IFilterState<T> {
+interface IMultiFilerState<T : MultiFilter> : IFilterState<T> {
     var selectedFilterList: List<T>
     fun setFilter(filterList: List<T>)
 }
 
-class SingleFilterState<T : Filter.SingleFilter>(
-    initFilter: T? = null,
+class SingleFilterState<T : SingleFilter>(
     override val filterList: List<T>,
 ) : ISingleFilterState<T> {
-    override var selectedFilter by mutableStateOf(initFilter)
+    override var selectedFilter by mutableStateOf<T?>(null)
 
     override fun selectFilter(filter: T) {
         selectedFilter = filter
@@ -40,11 +41,10 @@ class SingleFilterState<T : Filter.SingleFilter>(
     }
 }
 
-open class MultiFilterState<T : Filter.MultiFilter>(
-    initFilterList: List<T> = emptyList(),
+open class MultiFilterState<T : MultiFilter>(
     override val filterList: List<T>,
 ) : IMultiFilerState<T> {
-    override var selectedFilterList by mutableStateOf(initFilterList)
+    override var selectedFilterList by mutableStateOf(emptyList<T>())
 
     override fun selectFilter(filter: T) {
         selectedFilterList = if (filter in selectedFilterList) {
@@ -63,10 +63,9 @@ open class MultiFilterState<T : Filter.MultiFilter>(
     }
 }
 
-class MultiFilterForQueryState<T : Filter.MultiFilter>(
-    initFilterList: List<T> = emptyList(),
+class MultiFilterForQueryState<T : MultiFilter>(
     override val filterList: List<T>,
-) : MultiFilterState<T>(initFilterList, filterList) {
+) : MultiFilterState<T>(filterList) {
 
     override fun selectFilter(filter: T) {
         if (selectedFilterList.size + 1 == filterList.size) {


### PR DESCRIPTION
- Filter, SingleFilter, MultiFilter sealed interface -> interface로 변경
  - when 분기 없음, 구현 시 네이밍만 길어짐
  - Filter엔 `key`, SingleFilter엔 `displayName`을 선언해 구현체에 override해서 사용 -> 제너릭 타입에서도 사용 가능 -> 구조가 바뀌면 인터페이스 추가 분리가 필요함

- Region, Category, EventType sealed class -> enum class로 변경
  - companion object에 values()로 전체 리스트 하드코딩 -> 유지보수성 떨어짐 -> Enum.entries로 캐시된 리스트 사용

- IFilterState 하위 interface 수정
  - 불필요한 initFilter 삭제
  - 전체 Filter 리스트는 내부에서 사용됨 -> 생성자로 넘겨주는게 불가피함